### PR TITLE
Drop PHP 7 Support + Bump SDK To 2.0.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,12 +10,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-version: [
-          '7.1',
-          '7.2',
-          '7.3',
-          '7.4',
           '8.0',
           '8.1',
           '8.2',
@@ -40,9 +37,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php-${{ matrix.php-version }}-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.0
+
+This release drops support for PHP 7 (now end-of-life)
+ - the minimum supported PHP version is now 8.0
+
 ## 1.1.0
 
 This release includes support for our new InPerson and Terminal APIs

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=8.0",
         "ext-curl": "*",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^9.0",
+        "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "3.*"
     },
     "autoload": {

--- a/lib/Ryft/Version.php
+++ b/lib/Ryft/Version.php
@@ -4,6 +4,6 @@ namespace Ryft;
 
 final class Version
 {
-    public const SDK_VERSION = '1.1.0';
+    public const SDK_VERSION = '2.0.0';
     public const SDK_NAME = 'ryft-php-sdk';
 }


### PR DESCRIPTION
- `php` requirement raised to `>=8.0` (PHP 7 is EOL)
- `phpunit/phpunit` to `^9.6` (patched line for CVE-2026-24765)
- CI matrix trimmed to `8.0`-`8.5`, `fail-fast: false`
- vendor cache keyed per PHP version + `composer.json` hash (lock is untracked)