### PR TITLE
Fix Base URL Detection For Production Keys + Bump SDK To 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1
+
+This release fixes base URL detection so production keys route to the live API
+ - production keys (`sk_...`) previously routed to the sandbox environment
+ - invalid keys (no `sk_` prefix) now throw an `InvalidArgumentException`
+
 ## 2.0.0
 
 This release drops support for PHP 7 (now end-of-life)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ composer install ryftpay/ryft-php
 
 ## Usage
     
-The SDK must be configured with your account's secret key, available in the Ryft Dashboard. The SDK will automatically determine the environment based on the provided key. For example, `sk_sandbox...` will point to `sandbox`, while `sk_live` will point to `production`.
+The SDK must be configured with your account's secret key, available in the Ryft Dashboard. The SDK will automatically determine the environment based on the provided key. For example, `sk_sandbox...` will point to `sandbox`, while `sk_` will point to `production`.
 
 ### Importing the SDK
 

--- a/lib/Ryft/Utils.php
+++ b/lib/Ryft/Utils.php
@@ -2,17 +2,26 @@
 
 namespace Ryft;
 
+use InvalidArgumentException;
+
 class Utils
 {
     private const LIVE_URL = 'https://api.ryftpay.com/v1';
     private const SANDBOX_URL = 'https://sandbox-api.ryftpay.com/v1';
-    private const KEY_QUERY = 'sk_live';
+    
+    private const SANDBOX_PREFIX = 'sk_sandbox';
+    private const LIVE_PREFIX = 'sk_';
 
     public static function determineBaseUrl(string $secretKey): string
     {
-        if (substr($secretKey, 0, strlen(self::KEY_QUERY)) == self::KEY_QUERY) {
+        if (strncmp($secretKey, self::SANDBOX_PREFIX, strlen(self::SANDBOX_PREFIX)) === 0) {
+            return self::SANDBOX_URL;
+        }
+
+        if (strncmp($secretKey, self::LIVE_PREFIX, strlen(self::LIVE_PREFIX)) === 0) {
             return self::LIVE_URL;
         }
-        return self::SANDBOX_URL;
+
+        throw new InvalidArgumentException("Invalid secret key: expected prefix 'sk_'");
     }
 }

--- a/lib/Ryft/Version.php
+++ b/lib/Ryft/Version.php
@@ -4,6 +4,6 @@ namespace Ryft;
 
 final class Version
 {
-    public const SDK_VERSION = '2.0.0';
+    public const SDK_VERSION = '2.0.1';
     public const SDK_NAME = 'ryft-php-sdk';
 }

--- a/tests/Ryft/UtilsTest.php
+++ b/tests/Ryft/UtilsTest.php
@@ -9,22 +9,23 @@ class UtilsTest extends TestCase
 {
     public function testDetermineBaseUrlWithLiveKey(): void
     {
-        $liveKey = 'sk_live_1234567890abcdef';
+        $liveKey = 'sk_1234567890abcdef';
         $expectedUrl = 'https://api.ryftpay.com/v1';
         $this->assertEquals($expectedUrl, Utils::determineBaseUrl($liveKey));
     }
 
     public function testDetermineBaseUrlWithSandboxKey(): void
     {
-        $sandboxKey = 'sk_test_1234567890abcdef';
+        $sandboxKey = 'sk_sandbox_1234567890abcdef';
         $expectedUrl = 'https://sandbox-api.ryftpay.com/v1';
         $this->assertEquals($expectedUrl, Utils::determineBaseUrl($sandboxKey));
     }
 
-    public function testDetermineBaseUrlWithRandomKey(): void
+    public function testDetermineBaseUrlWithInvalidKey(): void
     {
         $randomKey = 'anything_else';
-        $expectedUrl = 'https://sandbox-api.ryftpay.com/v1';
-        $this->assertEquals($expectedUrl, Utils::determineBaseUrl($randomKey));
+        $this->expectException(\InvalidArgumentException::class);
+        Utils::determineBaseUrl($randomKey);
     }
+
 }


### PR DESCRIPTION
Supersedes #5 — cherry-picked from @lorenzoparis-ryft's fork (authorship preserved) onto the new PHP 8 baseline, with the version bump bundled in.

- `Utils::determineBaseUrl` routes `sk_sandbox...` keys to sandbox, `sk_...` keys to production (previously only `sk_live` matched, so production keys silently routed to sandbox)
- keys without an `sk_` prefix now throw `InvalidArgumentException` instead of defaulting to sandbox
- `README` updated to match
- `SDK_VERSION` to `2.0.1` + `CHANGELOG` entry